### PR TITLE
Results correction eval week 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,25 +164,7 @@ ___
 
 - **Bonus points**:
   - Xenia, Ben, Scott
-  - People that have not received bouns points in previous weeks (random selection).   
-
-### Forecast 8 Points Awarded:
-- **One Week forecast (10/11-10/17)**:
-  - Observed flow = 68.843 cfs
-  - First place: 67.81 cfs, Abigail
-  - Second place: 70.00 cfs, Camilo
-  - Third place: 70.38 cfs, Ben
-
-- **Two week forecast (m/dd - m/dd)**:
-  - Observed flow = 61.857 cfs
-  - First place: 61.5 cfs, Lourdes
-  - Second place: 62.6 cfs, Ben
-  - Third place: 60.0 cfs, Danielle
-
-- **Bonus points**:
-  - NAMES
-  - Reason
-
+  - People that have not received any bonus points in previous weeks (random selection).   
 
 -----
 ### Template forecast scoring text copy this above and fill out the info to add a new week.


### PR DESCRIPTION
Results were displayed two times, one under week 7 eval and other under Week 8 eval. Week 8 section deleted.